### PR TITLE
Fix parsing of IPv4 address in SOCKS4A

### DIFF
--- a/SocksLib/protocol/Socks4RequestMessage.cpp
+++ b/SocksLib/protocol/Socks4RequestMessage.cpp
@@ -52,7 +52,7 @@ SocksProtocolMessage::ParseResult Socks4RequestMessage::parse(QByteArray &bytes,
     quint32 ipv4Bytes;
     stream >> ipv4Bytes;
     QHostAddress v4(ipv4Bytes);
-    if ((ipv4Bytes & 0x000000ff) == ipv4Bytes)
+    if (((ipv4Bytes & 0x000000ff) == ipv4Bytes) && (ipv4Bytes > 0))
         _addressType = SocksProtocolMessage::DomainName;
     else
     {


### PR DESCRIPTION
According to the protocol a domain is used instead of an IPv4 address if the address is `0.0.0.x` with `x` non-zero.

Since `(0x00000000 & 0x000000ff) == 0x00000000` the IP address `0.0.0.0` was considered to be a domain as well, so we need to check if not only the first 3 octets are zero but if the last octet is non-zero as well.

I'm not sure if any client sets `0.0.0.0` as IP address. I didn't see a real life issue with this, but nonetheless let's try to be true to the specification.