### PR TITLE
Add support for connection filtering

### DIFF
--- a/SocksLib/SocksConnection.cpp
+++ b/SocksLib/SocksConnection.cpp
@@ -6,6 +6,7 @@
 #include "states/InitialState.h"
 #include "decorators/QIODeviceDecorator.h"
 #include "decorators/ThrottlingDecorator.h"
+#include "filters/ConnectionFilter.h"
 
 SocksConnection::SocksConnection(QAbstractSocket *socket,QObject *parent) :
     QObject(parent)
@@ -49,11 +50,25 @@ SocksConnection::~SocksConnection()
 
     if (!_connectionState.isNull())
         delete _connectionState;
+    if (!_connectionFilter.isNull())
+        delete _connectionFilter;
 }
 
 QPointer<SocksState> SocksConnection::connectionState()
 {
     return _connectionState;
+}
+
+QPointer<ConnectionFilter> SocksConnection::connectionFilter()
+{
+    return _connectionFilter;
+}
+
+void SocksConnection::setConnectionFilter(ConnectionFilter *connectionFilter)
+{
+    if (!_connectionFilter.isNull())
+        delete _connectionFilter;
+    _connectionFilter = connectionFilter;
 }
 
 SocksProtocolMessage::SocksVersion SocksConnection::socksVersion() const

--- a/SocksLib/SocksConnection.h
+++ b/SocksLib/SocksConnection.h
@@ -12,6 +12,7 @@
 #include "protocol/SocksProtocolMessage.h"
 
 class SocksState;
+class ConnectionFilter;
 
 class SocksConnection : public QObject
 {
@@ -21,6 +22,9 @@ public:
     virtual ~SocksConnection();
 
     QPointer<SocksState> connectionState();
+
+    QPointer<ConnectionFilter> connectionFilter();
+    void setConnectionFilter(ConnectionFilter *connectionFilter);
 
     SocksProtocolMessage::SocksVersion socksVersion() const;
     void setSocksVersion(SocksProtocolMessage::SocksVersion);
@@ -53,7 +57,7 @@ private:
 
     bool _socksVersionSet;
     SocksProtocolMessage::SocksVersion _socksVersion;
-    
+    QPointer<ConnectionFilter> _connectionFilter;
 };
 
 #endif // SOCKSCONNECTION_H

--- a/SocksLib/SocksLib.pro
+++ b/SocksLib/SocksLib.pro
@@ -36,6 +36,8 @@ HEADERS += \
     SocksConnection.h \
     decorators/ThrottlingDecorator.h \
     decorators/QIODeviceDecorator.h \
+    filters/ConnectionFilter.h \
+    filters/ConnectionFilterFactory.h \
     protocol/SocksReplyMessage4a.h \
     protocol/SocksProtocolMessage.h \
     protocol/Socks5UDPRequestMessage.h \

--- a/SocksLib/SocksServer.h
+++ b/SocksLib/SocksServer.h
@@ -9,6 +9,7 @@
 
 #include "SocksLib_global.h"
 class SocksConnection;
+class ConnectionFilterFactory;
 
 class SOCKSLIBSHARED_EXPORT SocksServer : public QObject
 {
@@ -20,6 +21,7 @@ public:
                          QObject *parent = 0);
     ~SocksServer();
 
+    void setConnectionFilterFactory(ConnectionFilterFactory *connectionFilterFactory);
     void start();
 
     bool isStarted() const;
@@ -38,6 +40,7 @@ private:
     qreal _throttle;
     QPointer<QTcpServer> _serverSock;
     QList<QPointer<SocksConnection> > _connections;
+    QPointer<ConnectionFilterFactory> _connectionFilterFactory;
     
 };
 

--- a/SocksLib/filters/ConnectionFilter.h
+++ b/SocksLib/filters/ConnectionFilter.h
@@ -1,0 +1,30 @@
+#ifndef CONNECTIONFILTER_H
+#define CONNECTIONFILTER_H
+
+#include "SocksLib_global.h"
+
+#include <QObject>
+#include <QHostAddress>
+
+class SOCKSLIBSHARED_EXPORT ConnectionFilter : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ConnectionFilter(const QHostAddress &clientAddress, const quint16 clientPort, QObject *parent = 0) :
+        QObject(parent),
+        m_clientAddress(clientAddress),
+        m_clientPort(clientPort)
+    {}
+
+    virtual ~ConnectionFilter() {}
+
+    virtual bool isConnectionToAddressAllowed(const QHostAddress &address, const quint16 port) = 0;
+    virtual bool isConnectionToDomainAllowed(const QString &domain, const quint16 port) = 0;
+
+protected:
+    const QHostAddress m_clientAddress;
+    const quint16 m_clientPort;
+};
+
+#endif // CONNECTIONFILTER_H

--- a/SocksLib/filters/ConnectionFilterFactory.h
+++ b/SocksLib/filters/ConnectionFilterFactory.h
@@ -1,0 +1,21 @@
+#ifndef CONNECTIONFILTERFACTORY_H
+#define CONNECTIONFILTERFACTORY_H
+
+#include "SocksLib_global.h"
+#include "ConnectionFilter.h"
+
+#include <QObject>
+#include <QHostAddress>
+
+class SOCKSLIBSHARED_EXPORT ConnectionFilterFactory: public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ConnectionFilterFactory(QObject *parent = 0) : QObject(parent) {}
+    virtual ~ConnectionFilterFactory() {}
+
+    virtual ConnectionFilter *newConnectionFilter(const QHostAddress &address, const quint16 port) const = 0;
+};
+
+#endif // CONNECTIONFILTERFACTORY_H

--- a/SocksLib/states/Socks5ConnectState.h
+++ b/SocksLib/states/Socks5ConnectState.h
@@ -8,6 +8,8 @@
 #include <QTcpSocket>
 #include <QHostInfo>
 
+class ConnectionFilter;
+
 class Socks5ConnectState : public SocksState
 {
     Q_OBJECT
@@ -30,8 +32,9 @@ private slots:
     void handleDomainLookupResult(const QHostInfo& info);
 
 private:
-    void handleIP();
-    void handleDomain();
+    void handleIP(const bool addressPortOkay);
+    void handleDomain(const bool domainOkay);
+    QPointer<ConnectionFilter> connectionFilter() const;
 
     QSharedPointer<Socks5RequestMessage> _request;
     QTcpSocket * _socket;


### PR DESCRIPTION
This is not actually doing anything yet, since there is never a
connection filter or factory instantiated. One has to implement a custom
connection filter and a factory which instantiates objects of this
filter.

I've chosen this approach, since it allows to have more complex
filtering depending on your need / use case.
Instances of connection filters are created per connection, since it
allows to have a per connection state for each filter, which then could
do some caching or cleanup or whatever is necessary.

---

I tried to stay true to your coding style, except for member variable names. I used a `m_` prefix instead of `_varname`, since it might cause confusion as underscores followed by an uppercase letter are reserved, see [What are the rules about using an underscore in a C++ identifier?](http://stackoverflow.com/q/228783). I only did that for the two newly added classes though.