### PR TITLE
Delete[] whole array instead of just one item

### DIFF
--- a/SocksLib/protocol/Socks4RequestMessage.cpp
+++ b/SocksLib/protocol/Socks4RequestMessage.cpp
@@ -99,7 +99,7 @@ SocksProtocolMessage::ParseResult Socks4RequestMessage::parse(QByteArray &bytes,
     char * domainNameBytes = new char[domainNameLength];
     stream.readRawData(domainNameBytes,domainNameLength);
     const QString domainName = QString::fromLatin1(domainNameBytes,domainNameLength);
-    delete domainNameBytes;
+    delete[] domainNameBytes;
 
     _domainName = domainName;
 

--- a/SocksLib/protocol/Socks5RequestMessage.cpp
+++ b/SocksLib/protocol/Socks5RequestMessage.cpp
@@ -97,11 +97,11 @@ SocksProtocolMessage::ParseResult Socks5RequestMessage::parse(QByteArray &bytes,
         {
             if (error)
                 *error = "Failed to read IPv6 address bytes";
-            delete ipv6buf;
+            delete[] ipv6buf;
             return Failure;
         }
         _address = QHostAddress(ipv6buf);
-        delete ipv6buf;
+        delete[] ipv6buf;
         if (_address.isNull())
         {
             if (error)

--- a/SocksLib/protocol/Socks5UDPRequestMessage.cpp
+++ b/SocksLib/protocol/Socks5UDPRequestMessage.cpp
@@ -90,11 +90,11 @@ SocksProtocolMessage::ParseResult Socks5UDPRequestMessage::parse(QByteArray &byt
         {
             if (error)
                 *error = "Failed to read IPv6 address bytes";
-            delete ipv6buf;
+            delete[] ipv6buf;
             return Failure;
         }
         _address = QHostAddress(ipv6buf);
-        delete ipv6buf;
+        delete[] ipv6buf;
         if (_address.isNull())
         {
             if (error)


### PR DESCRIPTION
Clang complained about "delete" being applied to an array of new'd items. This fixes the memory leak.